### PR TITLE
fix: exclude null values in sort conditions

### DIFF
--- a/src/book/book.service.ts
+++ b/src/book/book.service.ts
@@ -37,20 +37,8 @@ export class BookService {
   }
 
   async getAllBooks(page: number = 1, limit: number = 20, filter: BookFilterDto = {}) {
-    const filterConditions = getFilterConditions(filter)
     const sortConditions = getSortConditions(filter)
-
-    const where = {
-      OR: [
-        filterConditions,
-        {
-          isbn: {
-            contains: filter.title,
-            mode: 'insensitive',
-          },
-        },
-      ],
-    }
+    const where = getFilterConditions(filter, sortConditions)
 
     const offset = (page - 1) * limit
 

--- a/src/book/dto/book.dto.ts
+++ b/src/book/dto/book.dto.ts
@@ -135,11 +135,6 @@ export class BookFilterDto {
 
   @IsOptional()
   @IsString()
-  @ApiProperty({ required: false, description: 'Sort by price' })
-  sortByPrice?: 'asc' | 'desc'
-
-  @IsOptional()
-  @IsString()
   @ApiProperty({ required: false, description: 'Sort by rating' })
   sortByRating?: 'asc' | 'desc'
 

--- a/src/book/dto/book.dto.ts
+++ b/src/book/dto/book.dto.ts
@@ -135,8 +135,18 @@ export class BookFilterDto {
 
   @IsOptional()
   @IsString()
+  @ApiProperty({ required: false, description: 'Sort by price' })
+  sortByPrice?: 'asc' | 'desc'
+
+  @IsOptional()
+  @IsString()
   @ApiProperty({ required: false, description: 'Sort by rating' })
   sortByRating?: 'asc' | 'desc'
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ required: false, description: 'Sort by rating count' })
+  sortByRatingCount?: 'asc' | 'desc'
 
   // We can't use IsBoolean here because the query parameter is a string
   @IsOptional()

--- a/src/book/utils/book.utils.ts
+++ b/src/book/utils/book.utils.ts
@@ -1,4 +1,7 @@
-import { applyFilterMapping } from '../../common/utils/common.filter.utils'
+import {
+  applyFilterMapping,
+  excludeNullValuesFromFilters,
+} from '../../common/utils/common.filter.utils'
 import { BookFilterDto } from '../dto/book.dto'
 
 /**
@@ -44,18 +47,26 @@ const parseFilter = (filter: BookFilterDto) => ({
 
 const parseSort = (filter: BookFilterDto) => ({
   ratingAvg: filter.sortByRating,
+  ratingCount: filter.sortByRatingCount,
 })
 
 const sortMappings = {
   ratingAvg: (value: string) => value,
+  ratingCount: (value: string) => value,
 }
 
 /**
  * Get filter conditions for book
  * @param queryFilters
  */
-export const getFilterConditions = (queryFilters: BookFilterDto) =>
-  applyFilterMapping(parseFilter(queryFilters), filterMappings)
+export const getFilterConditions = (
+  queryFilters: BookFilterDto,
+  sortConditions: Record<string, any>,
+) => {
+  const sortConditionsKeys = Object.keys(sortConditions)
+  const filters = applyFilterMapping(parseFilter(queryFilters), filterMappings)
+  return excludeNullValuesFromFilters(filters, sortConditionsKeys)
+}
 
 /**
  * Get sort conditions for book

--- a/src/common/utils/common.filter.utils.ts
+++ b/src/common/utils/common.filter.utils.ts
@@ -50,7 +50,7 @@ export const applyFilterMapping = (filter: Filter, filterMappings: FilterMapping
  * authorId: 1,
  * }
  * const filtersNotToBeNull = ['ratingCount']
- * const filters = addNotNullToFilterMapping(allFilters, filtersNotToBeNull)
+ * const filters = excludeNullValuesFromFilters(allFilters, filtersNotToBeNull)
  * const books = await this.prisma.book.findMany({where: filters})
  * const totalBooks = await this.prisma.book.count({where: filters})
  */

--- a/src/common/utils/common.filter.utils.ts
+++ b/src/common/utils/common.filter.utils.ts
@@ -37,3 +37,33 @@ export const applyFilterMapping = (filter: Filter, filterMappings: FilterMapping
   }
   return filterConditions
 }
+
+/**
+ * Add not null to filter mapping. Useful if you have sort conditions and you don't want to
+ * include null values.
+ * @param allFilters Filter object
+ * @param filtersNotToBeNull Filters not to be null
+ * @returns Filter object with specified filters not to be null
+ * @example
+ * const allFilters = {
+ * title: 'Book Title',
+ * authorId: 1,
+ * }
+ * const filtersNotToBeNull = ['ratingCount']
+ * const filters = addNotNullToFilterMapping(allFilters, filtersNotToBeNull)
+ * const books = await this.prisma.book.findMany({where: filters})
+ * const totalBooks = await this.prisma.book.count({where: filters})
+ */
+export const excludeNullValuesFromFilters = (
+  allFilters: Filter,
+  filtersNotToBeNull: string[],
+) => {
+  const filters = { ...allFilters }
+  filtersNotToBeNull.forEach((filter) => {
+    filters[filter] = {
+      not: null,
+      ...filters[filter],
+    }
+  })
+  return filters
+}


### PR DESCRIPTION
<!-- This template is from the following source:
https://www.pullchecklist.com/medium/pull-request-template

Feel free to modify it to fit your needs. -->

### 🛠 Changes being made

<!-- Here give examples of the changes you've made in this pull request. Include an itemized list if you can. It'll help the reviewer -->
Before these changes, if someone sorted by rating, the ratings with null would appear. This fixes this issue by filtering the null values of a parameter only if this parameter is being sorted.

Also added sortingByRatingCount
### ✨ What's the context?

<!-- What's the context for the changes? Are there any -->

### 🏎 Quality check

- [x] Are your changes following SOLID principles?

- [x] Did you make sure that there aren't any erroneous console logs, debuggers or leftover code in your changes?

- [x] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?
